### PR TITLE
Simplify versioning in SGX and TDX workflows

### DIFF
--- a/.github/workflows/build-and-release-sgx.yml
+++ b/.github/workflows/build-and-release-sgx.yml
@@ -2,15 +2,6 @@ name: Build and Release SGX Image
 
 on:
   workflow_dispatch:
-    inputs:
-      target_environment:
-        description: 'Target deployment environment'
-        required: true
-        default: 'staging'
-        type: choice
-        options:
-          - staging
-          - production
 
 permissions:
   contents: write
@@ -36,7 +27,6 @@ jobs:
           file: SGX.Dockerfile
           load: true
           tags: |
-            finquarium-proof:${{ github.run_number }}
             finquarium-proof:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -64,7 +54,7 @@ jobs:
 
       - name: Export GSC image to file
         run: |
-          docker save gsc-finquarium-proof:latest | gzip > gsc-finquarium-proof-${{ github.run_number }}.tar.gz
+          docker save gsc-finquarium-proof:latest | gzip > gsc-finquarium-proof.tar.gz
 
       - name: Generate verification data
         run: |
@@ -75,7 +65,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: gsc-finquarium-proof-image
-          path: gsc-finquarium-proof-${{ github.run_number }}.tar.gz
+          path: gsc-finquarium-proof.tar.gz
 
       - name: Upload verification data
         uses: actions/upload-artifact@v3
@@ -87,11 +77,10 @@ jobs:
         run: |
           echo "MRSIGNER: $(grep -oP 'mr_signer = "\K[^"]*' sigstruct.txt)" >> release_body.txt
           echo "MRENCLAVE: $(grep -oP 'mr_enclave = "\K[^"]*' sigstruct.txt)" >> release_body.txt
-          echo "Image SHA256: $(sha256sum gsc-finquarium-proof-${{ github.run_number }}.tar.gz | cut -d' ' -f1)" >> release_body.txt
+          echo "Image SHA256: $(sha256sum gsc-finquarium-proof.tar.gz | cut -d' ' -f1)" >> release_body.txt
 
       - name: Create Release and Upload Assets
         uses: softprops/action-gh-release@v1
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -101,7 +90,7 @@ jobs:
           draft: false
           prerelease: false
           files: |
-            ./gsc-finquarium-proof-${{ github.run_number }}.tar.gz
+            ./gsc-finquarium-proof.tar.gz
             ./sigstruct.txt
 
       - name: Cleanup signing key

--- a/.github/workflows/build-and-release-tdx.yml
+++ b/.github/workflows/build-and-release-tdx.yml
@@ -29,24 +29,23 @@ jobs:
           context: .
           load: true
           tags: |
-            finquarium-proof:${{ github.run_number }}
             finquarium-proof:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Export image to file
         run: |
-          docker save finquarium-proof:latest | gzip > finquarium-proof-${{ github.run_number }}.tar.gz
+          docker save finquarium-proof:latest | gzip > finquarium-proof.tar.gz
 
       - name: Generate release body
         run: |
-          echo "Image SHA256: $(sha256sum finquarium-proof-${{ github.run_number }}.tar.gz | cut -d' ' -f1)" >> release_body.txt
+          echo "Image SHA256: $(sha256sum finquarium-proof.tar.gz | cut -d' ' -f1)" >> release_body.txt
 
       - name: Upload image
         uses: actions/upload-artifact@v3
         with:
           name: finquarium-proof-image
-          path: finquarium-proof-${{ github.run_number }}.tar.gz
+          path: finquarium-proof.tar.gz
 
       - name: Create Release and Upload Assets
         uses: softprops/action-gh-release@v1
@@ -60,7 +59,7 @@ jobs:
           draft: false
           prerelease: false
           files: |
-            ./finquarium-proof-${{ github.run_number }}.tar.gz
+            ./finquarium-proof.tar.gz
 
       - name: Log build result
         if: always()


### PR DESCRIPTION
- Make SGX workflow manually triggered without environment selection
- Remove duplicate version numbers from artifact filenames
- Keep version only in release tags and names
- Align versioning pattern between SGX and TDX workflows